### PR TITLE
feat: add artifact_name option

### DIFF
--- a/.github/workflows/test_change_artifact_name.yml
+++ b/.github/workflows/test_change_artifact_name.yml
@@ -1,0 +1,15 @@
+name: Test - Change Artifact Name
+on: [workflow_dispatch]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Run PackSquash
+        uses: ./ # Uses an action in the root directory
+        with:
+          path: test/empty_resource_pack
+          artifact_name: Test Artifact Name

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ The action also supports additional parameters that might come in handy for more
 | `system_id` | Automatically generated | The system identifier PackSquash will use to generate cryptographic secrets. Unless you know what are you doing, it is recommended to leave this parameter unset, as doing so will let the action generate and use a suitable system identifier automatically. |
 | `options_file` | Generated from the action parameters | Use the specified options file instead of generating one with this action. Use this if you already have an options file you want to use with this action, or the options this action offers are not enough for your needs. Please note that the action relies on PackSquash generating an output file at `/var/lib/packsquash/pack.zip`, and it will use the options file you provide verbatim, overriding any other PackSquash option parameter you set. |
 | `action_cache_revision` | `﻿` (empty string) | The revision of the cache the action uses internally. You should only need to bump this revision if for some reason you want the action to not reuse any cached information, like the system identifier. This will render any previously generated ZIP file unusable for speed optimizations. |
-| `artifact_name` | `Optimized pack` | |
+| `artifact_name` | `Optimized pack` | The name of the workflow artifact containing the generated ZIP file that the action will upload. Later steps in the workflow will be able to download it by this name. Changing this may be needed in complex workflows, where several ZIP files are generated. |
 
 ## ⚙️ Example
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ The action also supports additional parameters that might come in handy for more
 | `system_id` | Automatically generated | The system identifier PackSquash will use to generate cryptographic secrets. Unless you know what are you doing, it is recommended to leave this parameter unset, as doing so will let the action generate and use a suitable system identifier automatically. |
 | `options_file` | Generated from the action parameters | Use the specified options file instead of generating one with this action. Use this if you already have an options file you want to use with this action, or the options this action offers are not enough for your needs. Please note that the action relies on PackSquash generating an output file at `/var/lib/packsquash/pack.zip`, and it will use the options file you provide verbatim, overriding any other PackSquash option parameter you set. |
 | `action_cache_revision` | `﻿` (empty string) | The revision of the cache the action uses internally. You should only need to bump this revision if for some reason you want the action to not reuse any cached information, like the system identifier. This will render any previously generated ZIP file unusable for speed optimizations. |
+| `artifact_name` | `Optimized pack` | |
 
 ## ⚙️ Example
 

--- a/action.yml
+++ b/action.yml
@@ -27,6 +27,10 @@ inputs:
     description: 'The revision of the cache the action uses internally. You should only need to bump this revision if for some reason you want the action to not reuse any cached information, like the system identifier. This will render any previously generated ZIP file unusable for speed optimizations.'
     required: false
     default: ''
+  artifact_name:
+    description: ''
+    required: false
+    default: 'Optimized pack'
   # Inputs that set PackSquash options
   recompress_compressed_files:
     description: 'If true, this parameter makes PackSquash try to compress files whose contents are already compressed just before adding them to the generated ZIP file, after all the file type specific optimizations have been applied.'

--- a/action.yml
+++ b/action.yml
@@ -28,7 +28,7 @@ inputs:
     required: false
     default: ''
   artifact_name:
-    description: ''
+    description: 'The name of the workflow artifact containing the generated ZIP file that the action will upload. Later steps in the workflow will be able to download it by this name. Changing this may be needed in complex workflows, where several ZIP files are generated.'
     required: false
     default: 'Optimized pack'
   # Inputs that set PackSquash options

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,7 +3,6 @@
 readonly UNUSABLE_CACHE_ERROR_CODE=129
 readonly ACTION_WORKING_DIR='/opt/action'
 readonly PACK_ZIP_PATH='/var/lib/packsquash/pack.zip'
-readonly PACK_ZIP_ARTIFACT_NAME='Optimized pack'
 readonly PROBLEM_MATCHER_FILE_NAME='packsquash-problem-matcher.json'
 
 # ----------------
@@ -332,7 +331,7 @@ if [ -n "${cache_may_be_used+x}" ]; then
     echo '::group::Restoring cached data'
     get_current_workflow_id
     download_latest_artifact "$GITHUB_REPOSITORY" "$(git -C "$GITHUB_WORKSPACE" rev-parse --abbrev-ref HEAD)" \
-        "$CURRENT_WORKFLOW_ID" "$PACK_ZIP_ARTIFACT_NAME" || true
+        "$CURRENT_WORKFLOW_ID" "$INPUT_ARTIFACT_NAME" || true
     mv -f "${PACK_ZIP_PATH##*/}" "$PACK_ZIP_PATH" >/dev/null 2>&1 || true
     node actions-cache.mjs 'system_id' restore "$options_file_hash" "$INPUT_ACTION_CACHE_REVISION"
     echo '::endgroup::'
@@ -395,7 +394,7 @@ esac
 cd "$ACTION_WORKING_DIR"
 
 echo '::group::Upload generated ZIP file as artifact'
-node actions-artifact-upload.mjs "${PACK_ZIP_PATH%/*}" "$PACK_ZIP_PATH" "$PACK_ZIP_ARTIFACT_NAME"
+node actions-artifact-upload.mjs "${PACK_ZIP_PATH%/*}" "$PACK_ZIP_PATH" "$INPUT_ARTIFACT_NAME"
 echo '::endgroup::'
 
 if [ -n "${cache_may_be_used+x}" ] && ! [ -f '/run/packsquash-cache-hit' ]; then


### PR DESCRIPTION
close #6

I just added the `artifact_name` setting. The description is not written. Can you please? @AlexTMjugador 

## TODO

- [x] Add option: `artifact_name`
- [x] Add description to yml ([action.yml](https://github.com/sya-ri/PackSquash-action/blob/%236_artifact_name/action.yml#L31))
- [x] Add description to readme ([README.md](https://github.com/sya-ri/PackSquash-action/blob/%236_artifact_name/README.md?plain=1#L60))

## Test
```yml
name: Test - Change Artifact Name
on: [workflow_dispatch]
jobs:
  build:
    runs-on: ubuntu-latest
    steps:
      - name: Clone repository
        uses: actions/checkout@v2
        with:
          fetch-depth: 0
      - name: Run PackSquash
        uses: ./ # Uses an action in the root directory
        with:
          path: test/empty_resource_pack
          artifact_name: Test Artifact Name
```

https://github.com/sya-ri/PackSquash-action/actions/runs/1718311242