### PR TITLE
refactor: Remove unnecessary argument to restore cache

### DIFF
--- a/actions-cache.mjs
+++ b/actions-cache.mjs
@@ -8,7 +8,7 @@ async function run() {
     if (process.argv[3] === 'save') {
         await saveCache(cached_file_paths, cache_key)
     } else {
-        return await restoreCache(cached_file_paths, cache_key, [cache_key]) !== undefined
+        return await restoreCache(cached_file_paths, cache_key) !== undefined
     }
 }
 


### PR DESCRIPTION
Using the same values ​​for `restoreKeys` and `key` doesn't make sense. Also, if omit `restoreKeys`, `[]` is used, so can delete it.